### PR TITLE
If passed an array of ports, generate a security group with just those ports, don't convert it to a range [Closes #25]

### DIFF
--- a/lib/cyoi/providers/clients/fog_provider_client.rb
+++ b/lib/cyoi/providers/clients/fog_provider_client.rb
@@ -147,6 +147,11 @@ class Cyoi::Providers::Clients::FogProviderClient
       defns = defns[:ports]
     end
 
+    # If we are passed an array of ports, preserve that
+    if defns.is_a?(Hash) && defns[:ports].is_a?(Array)
+      defns = defns[:ports]
+    end
+
     unless defns.is_a?(Array)
       defns = [defns]
     end

--- a/spec/unit/providers/clients/aws_provider_client_spec.rb
+++ b/spec/unit/providers/clients/aws_provider_client_spec.rb
@@ -111,7 +111,7 @@ describe Cyoi::Providers::Clients::AwsProviderClient do
       expect(subject).to receive(:puts).with(" -> opened foo ports TCP 443..443 from IP range 0.0.0.0/0")
       expect(subject).to receive(:puts).with(" -> opened foo ports TCP 4443..4443 from IP range 0.0.0.0/0")
 
-      subject.create_security_group("foo", "foo", [22, 443, 4443])
+      subject.create_security_group("foo", "foo", {ports: [22, 443, 4443]})
     end
   end
 end


### PR DESCRIPTION
This allows the syntax of:
```
cyoi_provider_client.create_security_group("sg", "name", {ports: [ 80, 444, 4443 ]}, attributes)
```
to work as intended. Also fixed the tests to look for this behavior.