### PR TITLE
Cleanup bits of the interactive prompts

### DIFF
--- a/lib/cyoi/cli/provider_addresses/address_cli_aws.rb
+++ b/lib/cyoi/cli/provider_addresses/address_cli_aws.rb
@@ -106,7 +106,7 @@ class Cyoi::Cli::Addresses::AddressCliAws
 
   def pretty_vpc_name(vpc)
     if name = vpc.tags["Name"]
-      "#{name} (#{vpc.cidr_block})"
+      "#{name} #{vpc.id} (#{vpc.cidr_block})"
     else
       "#{vpc.id} (#{vpc.cidr_block})"
     end

--- a/lib/cyoi/cli/provider_addresses/address_cli_aws.rb
+++ b/lib/cyoi/cli/provider_addresses/address_cli_aws.rb
@@ -72,7 +72,7 @@ class Cyoi::Cli::Addresses::AddressCliAws
   end
 
   def select_subnet_for_vpc(vpc)
-    subnets = provider_client.subnets.select {|subnet|  subnet.vpc_id = vpc.id}
+    subnets = provider_client.subnets.select {|subnet|  subnet.vpc_id == vpc.id}
     subnet = if subnets.size == 0
       $stderr.puts "ERROR: VPC #{pretty_vpc_name(vpc)} has no subnets yet."
       exit 1


### PR DESCRIPTION
1. There was a = vs == bug that resulted in every subnet being displayed for every VPC

1. If a VPC had a 'name', we weren't displaying the VPC ID, but if there were multiple VPCs with the same name and subnet ranges (as can happen easily when using automated tools), there was no way to differentiate between them. We now display the VPC ID all the time when choosing.
