### PR TITLE
Add AWS Asia Pacific (Seoul) Region

### DIFF
--- a/lib/cyoi/providers/clients/aws_provider_client.rb
+++ b/lib/cyoi/providers/clients/aws_provider_client.rb
@@ -176,6 +176,8 @@ class Cyoi::Providers::Clients::AwsProviderClient < Cyoi::Providers::Clients::Fo
     image_id = case region.to_s
     when "ap-northeast-1"
       "ami-df4b60de"
+    when "ap-northeast-2"
+      "ami-09dc1267"
     when "ap-southeast-1"
       "ami-2ce7c07e"
     when "eu-west-1"

--- a/lib/cyoi/providers/constants/aws_constants.rb
+++ b/lib/cyoi/providers/constants/aws_constants.rb
@@ -16,6 +16,7 @@ module Cyoi::Providers::Constants::AwsConstants
       { label: "Asia Pacific (Singapore) Region", code: "ap-southeast-1" },
       { label: "Asia Pacific (Sydney) Region", code: "ap-southeast-2" },
       { label: "Asia Pacific (Tokyo) Region", code: "ap-northeast-1" },
+      { label: "Asia Pacific (Seoul) Region", code: "ap-northeast-2" },
       { label: "South America (Sao Paulo) Region", code: "sa-east-1" },
       { label: "China (Beijing) Region", code: "cn-north-1" },
     ]


### PR DESCRIPTION
AWS launched AWS Asia Pacific (Seoul) Region on January 6th, 2016. This PR adds support for it.
